### PR TITLE
Added default gutter value.

### DIFF
--- a/modulo-columns.js
+++ b/modulo-columns.js
@@ -20,7 +20,7 @@
             this.getSize()
 
             // Add gutter and adjust column width/count accordingly
-            var gutter = this.options.gutter;
+            var gutter = this.options.gutter || 0;
             var containerWidth = this.size.innerWidth;
             this.columnWidth += gutter;
             var cols = this.cols = Math.floor((containerWidth + gutter) / this.columnWidth) || 1;


### PR DESCRIPTION
Default gutter value is usable when you using CSS margins. Before my change, leaving gutter unspecified breaking modulo columns functionality.
